### PR TITLE
Add link to relevant xkcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # libxkcdrandom
-Library implementing XKCD 221
+Library implementing xkcd 221 (https://xkcd.com/221/)


### PR DESCRIPTION
Fix xkcd capitalisation: "For those of us pedantic enough to want a rule, here it is: The preferred form is "xkcd", all lower-case." From: https://xkcd.com/about/